### PR TITLE
fix: ny dmv office and mo dmv office return values

### DIFF
--- a/spec/dmv_data_service_spec.rb
+++ b/spec/dmv_data_service_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe DmvDataService do
 
   describe '#ny_dmv_office_locations' do
     it 'can load new york dmv office locations' do
-      expect(@dds.ny_dmv_office_locations.size).to eq(170)
+      expect(@dds.ny_dmv_office_locations.size).to eq(172)
     end
   end
 
   describe '#mo_dmv_office_locations' do
     it 'can load missouri dmv office locations' do
-      expect(@dds.mo_dmv_office_locations.size).to eq(177)
+      expect(@dds.mo_dmv_office_locations.size).to eq(178)
     end
   end
 end


### PR DESCRIPTION
This PR updates the `dmv_data_service_spec.rb` file expect lines 36 & 42. 